### PR TITLE
Correctly parse the boolean env vars

### DIFF
--- a/config.js
+++ b/config.js
@@ -55,8 +55,8 @@ module.exports = {
       pass: process.env.SMTP_PASSWORD || ''
     },
     from: process.env.FROM_ADDRESS || '',
-    ignoreTLS: process.env.EMAIL_IGNORE_TLS || false,
-    secure: process.env.EMAIL_SECURE || false
+    ignoreTLS: process.env.EMAIL_IGNORE_TLS === 'true',
+    secure: process.env.EMAIL_SECURE === 'true'
   },
   ga: {
     tagId: process.env.GA_TAG_ID


### PR DESCRIPTION
This commit fixes a bug where an env var set to the string "false" will
be added to the config object 'as is'. i.e. As the string "false" which
is a truthy value in javascript. The new behaviour instead converts it
to a boolean.