### PR TITLE
RTMD-51 - made app trust proxy

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,6 +46,9 @@ app.use(function setBaseUrl(req, res, next) {
   next();
 });
 
+// Trust proxy for secure cookies
+app.set('trust proxy', 1);
+
 // Redis session storage
 
 logger.info('connecting to redis on ', config.redis.port, config.redis.host);


### PR DESCRIPTION
Added :-
 - app.set('trust proxy', 1);
to app.js.

This allows an Express app to have knowledge that it's sitting behind a proxy and that the X-Forwarded-* header fields may be trusted.

as described in the link below

http://expressjs.com/en/guide/behind-proxies.html