### PR TITLE
RTMD-85 bugfix - changing the report web address doesn't persist data…

### DIFF
--- a/apps/rotm/controllers/reports.js
+++ b/apps/rotm/controllers/reports.js
@@ -28,15 +28,17 @@ module.exports = class AddReportController extends Controller {
   }
 
   getValues(req, res, callback) {
-    let values = req.sessionModel.toJSON();
-    delete values.errorValues;
-    values = _.extend({}, values, req.sessionModel.get('errorValues'));
-    if (req.params.action === 'edit' && req.params.id !== undefined) {
-      const reports = req.sessionModel.get('reports');
-      const report = _.find(reports, {id: req.params.id});
-      values = Object.assign({}, report, values);
-    }
-    callback(null, values);
+    super.getValues(req, res, (err, values) => {
+      if (err) {
+        return callback(err);
+      }
+      if (req.params.action === 'edit' && req.params.id !== undefined) {
+        const reports = req.sessionModel.get('reports');
+        const report = _.find(reports, {id: req.params.id});
+        values = Object.assign({}, report, values);
+      }
+      return callback(null, values);
+    });
   }
 
   locals(req, res) {

--- a/apps/rotm/controllers/reports.js
+++ b/apps/rotm/controllers/reports.js
@@ -28,12 +28,15 @@ module.exports = class AddReportController extends Controller {
   }
 
   getValues(req, res, callback) {
+    let values = req.sessionModel.toJSON();
+    delete values.errorValues;
+    values = _.extend({}, values, req.sessionModel.get('errorValues'));
     if (req.params.action === 'edit' && req.params.id !== undefined) {
       const reports = req.sessionModel.get('reports');
       const report = _.find(reports, {id: req.params.id});
-      callback(null, report);
+      values = Object.assign({}, report, values);
     }
-    super.getValues(req, res, callback);
+    callback(null, values);
   }
 
   locals(req, res) {

--- a/test/unit/apps/rotm/controllers/reports.js
+++ b/test/unit/apps/rotm/controllers/reports.js
@@ -13,8 +13,6 @@ describe('Reports Controller', () => {
   class ControllerStub {}
 
   beforeEach(() => {
-    ControllerStub.prototype.getValues = sinon.stub();
-
     Controller = proxyquire('../../../../../apps/rotm/controllers/reports', {
       hof: {
         controllers: {
@@ -27,7 +25,8 @@ describe('Reports Controller', () => {
     req.sessionModel = {
       get: sinon.stub().returns([{id: 1}, {id: 2}, {id: 3}]),
       set: sinon.stub(),
-      unset: sinon.stub()
+      unset: sinon.stub(),
+      toJSON: sinon.stub().returns({})
     };
   });
 
@@ -92,25 +91,30 @@ describe('Reports Controller', () => {
   });
 
   describe('getValues', () => {
-    it('calls super if action is not edit', () => {
+    beforeEach(() => {
+      req.sessionModel.get.withArgs('errorValues').returns({error: 'value'})
+        .withArgs('reports').returns([{id: 1}, {id: 2}]);
+    });
+
+    it('calls callback with errorValues if action is not edit', () => {
       req.params.id = 1;
       req.params.action = 'delete';
       controller.getValues(req, res, callback);
-      ControllerStub.prototype.getValues.should.have.been.calledOnce;
+      callback.should.have.been.calledOnce.and.calledWithExactly(null, {error: 'value'});
     });
 
-    it('calls super if id is undefined', () => {
+    it('calls callback with errorValues if action is undefined', () => {
       req.params.action = 'edit';
       delete req.params.id;
       controller.getValues(req, res, callback);
-      ControllerStub.prototype.getValues.should.have.been.calledOnce;
+      callback.should.have.been.calledOnce.and.calledWithExactly(null, {error: 'value'});
     });
 
-    it('calls callback with null, and the report if passed edit and id', () => {
+    it('calls callback with the report and errorValues if passed edit and id', () => {
       req.params.action = 'edit';
       req.params.id = 2;
       controller.getValues(req, res, callback);
-      callback.should.have.been.calledOnce.and.calledWithExactly(null, {id: 2});
+      callback.should.have.been.calledOnce.and.calledWithExactly(null, {id: 2, error: 'value'});
     });
   });
 

--- a/test/unit/apps/rotm/controllers/reports.js
+++ b/test/unit/apps/rotm/controllers/reports.js
@@ -13,6 +13,7 @@ describe('Reports Controller', () => {
   class ControllerStub {}
 
   beforeEach(() => {
+    ControllerStub.prototype.getValues = sinon.stub();
     Controller = proxyquire('../../../../../apps/rotm/controllers/reports', {
       hof: {
         controllers: {
@@ -25,8 +26,7 @@ describe('Reports Controller', () => {
     req.sessionModel = {
       get: sinon.stub().returns([{id: 1}, {id: 2}, {id: 3}]),
       set: sinon.stub(),
-      unset: sinon.stub(),
-      toJSON: sinon.stub().returns({})
+      unset: sinon.stub()
     };
   });
 
@@ -92,8 +92,8 @@ describe('Reports Controller', () => {
 
   describe('getValues', () => {
     beforeEach(() => {
-      req.sessionModel.get.withArgs('errorValues').returns({error: 'value'})
-        .withArgs('reports').returns([{id: 1}, {id: 2}]);
+      req.sessionModel.get.withArgs('reports').returns([{id: 1}, {id: 2}]);
+      ControllerStub.prototype.getValues.callsArgWith(2, null, {error: 'value'});
     });
 
     it('calls callback with errorValues if action is not edit', () => {


### PR DESCRIPTION
… on error

* move logic from wizard controller getValues to own method
* if editing report with id, extend with errorValues
* also fixed bug with callback being called twice