### PR TITLE
Fix path for shared translation files

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cover": "istanbul cover _mocha && istanbul check-coverage",
     "sass": "./node_modules/node-sass/bin/node-sass ./assets/scss/app.scss ./public/css/app.css --include-path ./node_modules",
     "create:public": "mkdir -p ./public/js ./public/css ./public/images",
-    "hof-transpile": "hof-transpiler ./apps/**/translations/src -w --shared ./node_modules/hof-template-partials/translations",
+    "hof-transpile": "hof-transpiler ./apps/**/translations/src --shared ./node_modules/hof-template-partials/translations/src",
     "prepareapp": "npm run create:public; npm run sass; npm run browserify; npm run copy:images; npm run hof-transpile",
     "postinstall": "bash -c 'if [[ ${NODE_ENV} != production ]]; then npm run prepareapp; fi;'"
   },


### PR DESCRIPTION
This needs to have the `src/` on the end or it will throw when it finds .js files in the parent directory.