### PR TITLE
Use valid SPDX licence expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.4",
   "main": "app.js",
   "description": "A Home Office application for reporting online terrorist material.",
-  "license": "GPLv2",
+  "license": "GPL-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/UKHomeOffice/rotm.git"


### PR DESCRIPTION
The [Software Package Data Exchange](https://spdx.org/) defines a standard format for
machine-readable licence data. Previously, we were using a non-standard
identifier for the GPLv2; this commit amends it to adhere to the
standard.

Node's package manager complains about the invalid SPDX expression when building the app;
by fixing this we get rid of the warning.