### PR TITLE
Don't use ValidationError for file-vault failures

### DIFF
--- a/apps/rotm/behaviours/save-image.js
+++ b/apps/rotm/behaviours/save-image.js
@@ -2,7 +2,6 @@
 
 const _ = require('lodash');
 const Model = require('../models/image-upload');
-const ValidationError = require('hof-form-controller').ValidationError;
 
 module.exports = superclass => class extends superclass {
 
@@ -30,7 +29,7 @@ module.exports = superclass => class extends superclass {
         })
         .catch((err) => {
           req.log('debug', 'Image not saved to S3');
-          next(new ValidationError('unsaved', err));
+          next(err);
         });
     }
     super.saveValues.apply(this, arguments);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "hof": "^13.2.1",
     "hof-behaviour-summary-page": "^3.1.0",
     "hof-build": "^1.5.0",
-    "hof-form-controller": "^5.1.0",
     "hof-model": "^3.1.2",
     "hof-theme-govuk": "^4.1.0",
     "lodash": "^4.17.4"

--- a/test/unit/behaviours/save-image.js
+++ b/test/unit/behaviours/save-image.js
@@ -3,7 +3,6 @@
 const Behaviour = require('../../../apps/rotm/behaviours/save-image');
 const reqres = require('hof-util-reqres');
 const Model = require('../../../apps/rotm/models/image-upload');
-const ValidationError = require('hof-form-controller').ValidationError;
 
 describe('behaviours/save-image', () => {
 
@@ -169,8 +168,7 @@ describe('behaviours/save-image', () => {
 
         it('the next callback is called with a Validation error', (done) => {
           instance.saveValues(req, res, (err) => {
-            expect(err).to.be.an.instanceof(ValidationError);
-            expect(err.key).to.equal('unsaved');
+            expect(err).to.equal(error);
             done();
           });
         });


### PR DESCRIPTION
When validation errors are thrown they display with a message "Please fix the following error". If saving the file to file vault has failed, then there is nothing the user can "fix" to make it work, so displaying a validation message is not appropriate, and an application error should be displayed.

As an aside, the validation error is broken anyway as validation errors need to be passed in the form 

```
next({
  key1: new ValidationError(...),
  key2: new ValidationError(...)
});
```

(yes, this is both nasty and a little counterintuitive, but it's so you can throw multiple validation errors per step)