### PR TITLE
Add image thumbnail on confirm page

### DIFF
--- a/apps/rotm/acceptance/features/check-your-report.js
+++ b/apps/rotm/acceptance/features/check-your-report.js
@@ -42,3 +42,10 @@ Scenario('I can edit "source" field and return to summary page', (
   I.seeInCurrentUrl('/check-your-report');
   I.see('A different source', 'td[data-field="source"]');
 });
+
+Scenario('I see an image thumbnail if I have uploaded an image', (
+  I
+) => {
+  I.seeElement('td[data-field="image"] img');
+});
+

--- a/apps/rotm/index.js
+++ b/apps/rotm/index.js
@@ -26,7 +26,8 @@ module.exports = {
         'image'
       ],
       behaviours: [skipStep, saveImage, createThumbnail],
-      next: '/add-image'
+      next: '/add-image',
+      continueOnEdit: true
     },
     '/add-image': {
       fields: [
@@ -39,7 +40,8 @@ module.exports = {
           value: 'no'
         }
       }],
-      next: '/check-your-report'
+      next: '/check-your-report',
+      continueOnEdit: true
     },
     '/check-your-report': {
       prereqs: ['/image'],

--- a/apps/rotm/index.js
+++ b/apps/rotm/index.js
@@ -49,6 +49,7 @@ module.exports = {
         'summary': [
           'source',
           'more-info'
+          // image preview is hardcoded in the page template
         ]
       },
       next: '/confirmation'

--- a/apps/rotm/translations/src/en/pages.json
+++ b/apps/rotm/translations/src/en/pages.json
@@ -26,6 +26,9 @@
       },
       "more-info": {
         "label": "Further information"
+      },
+      "image-preview": {
+        "label": "Image"
       }
     }
   },

--- a/apps/rotm/views/check-your-report.html
+++ b/apps/rotm/views/check-your-report.html
@@ -10,6 +10,16 @@
               <td><a href="{{baseUrl}}{{step}}/edit#{{field}}" id="{{field}}-change">{{#t}}buttons.change{{/t}}</a></td>
             </tr>
           {{/fields}}
+          <tr>
+            <th>{{#t}}pages.confirm.fields.image-preview.label{{/t}}</th>
+            {{#values.image-preview}}
+              <td data-field="image"><img src="{{values.image-preview}}" /></td>
+            {{/values.image-preview}}
+            {{^values.image-preview}}
+              <td data-field="image">{{#t}}pages.confirm.undefined{{/t}}</td>
+            {{/values.image-preview}}
+            <td><a href="{{baseUrl}}/image/edit" id="image-change">{{#t}}buttons.change{{/t}}</a></td>
+          </tr>
         </tbody>
       </table>
     {{/rows}}


### PR DESCRIPTION
Adds the uploaded image to the check answers screen.

Outstanding issues not in the scope of the ticket:

* How does a user delete an image that they've previously uploaded without adding a new one?