### PR TITLE
Fix file vault params

### DIFF
--- a/apps/rotm/models/image-upload.js
+++ b/apps/rotm/models/image-upload.js
@@ -27,11 +27,6 @@ module.exports = class UploadModel extends Model {
         }
         resolve(data);
       });
-    }).then(data => {
-      return this.auth().then(bearer => {
-        data.url = (data.url.replace('/file', '/vault')) + '&token=' + bearer.bearer;
-        return data;
-      });
     });
   }
 

--- a/apps/rotm/models/image-upload.js
+++ b/apps/rotm/models/image-upload.js
@@ -12,7 +12,7 @@ module.exports = class UploadModel extends Model {
       };
       const reqConf = url.parse(this.url(attributes));
       reqConf.formData = {
-        image: {
+        document: {
           value: this.get('data'),
           options: {
             filename: this.get('name'),

--- a/mocks/image-upload.js
+++ b/mocks/image-upload.js
@@ -6,7 +6,7 @@ const busboy = require('busboy-body-parser');
 router.use(busboy());
 
 router.post('/', (req, res, next) => {
-  if (req.files.image) {
+  if (req.files.document) {
     res.json({'url': `http://s3.com/foo/${Math.random()}`});
   } else {
     next(new Error('No file uploaded'));

--- a/test/unit/models/image-upload.js
+++ b/test/unit/models/image-upload.js
@@ -49,7 +49,7 @@ describe('models/image-upload', () => {
       const response = model.save();
       return expect(response).to.eventually.deep.equal({
         api: 'response',
-        url: '/vault/12341212132123?foo=bar&token=myaccesstoken'
+        url: '/file/12341212132123?foo=bar'
       });
     });
 

--- a/test/unit/models/image-upload.js
+++ b/test/unit/models/image-upload.js
@@ -71,7 +71,7 @@ describe('models/image-upload', () => {
       return response.then(() => {
         expect(uploadedFile.request).to.have.been.calledWith(sinon.match({
           formData: {
-            image: {
+            document: {
               value: 'foo',
               options: {
                 filename: 'myfile.png',


### PR DESCRIPTION
* The correct property name for file-vault uploads is "document" (see https://github.com/UKHomeOffice/file-vault/blob/master/controllers/file.js#L116)
* The URLs returned should not contain a bearer token