### PR TITLE
Pass redis config into hof

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const options = {
   routes: [
     require('./apps/rotm')
   ],
+  redis: config.redis,
   csp: config.csp
 };
 


### PR DESCRIPTION
At the moment the config is being defined in config.js but then not actually used anywhere. Pass the config defined into hof so it is used in place of defaults for session store configuration.