### PR TITLE
wait for deploy to finish before running tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -139,6 +139,7 @@ pipeline:
       - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
       - docker run -d --userns host --net host --name=selenium-$${DRONE_COMMIT_SHA} selenium/standalone-chrome
+      - sleep 5
       - docker run -e TEST_URL=https://rotm-$${DRONE_DEPLOY_TO}.notprod.homeoffice.gov.uk --rm --userns host --net host acceptance-$${DRONE_COMMIT_SHA}
       - docker rm -vf "selenium-$${DRONE_COMMIT_SHA}"
     when:


### PR DESCRIPTION
Tests are running after deploy, before pods have restarted on the kube cluster