### PR TITLE
[RTMD-179] - Accessibility: remove tab focus for hidden elements

### DIFF
--- a/apps/rotm/acceptance/features/tab-focus.js
+++ b/apps/rotm/acceptance/features/tab-focus.js
@@ -1,0 +1,22 @@
+'use strict';
+
+Feature('Accessibility Tab focus');
+
+Scenario('Given I am on image I can not tab into a hidden element', (
+  I
+) => {
+  I.amOnPage('/');
+  I.completeToStep('/image');
+  // previously if you tabbed into the elements 6 times then the hidden element would get focused on
+  I.pressKey('Tab');
+  I.pressKey('Tab');
+  I.pressKey('Tab');
+  I.pressKey('Tab');
+  I.pressKey('Tab');
+  I.pressKey('Tab');
+  I.hasFocus('#file-upload')
+    .then((bool) => {
+      bool !== true;
+    }
+  );
+});

--- a/apps/rotm/views/image.html
+++ b/apps/rotm/views/image.html
@@ -6,7 +6,7 @@
       <input name="image" id="file-upload" type="file" accept=".png, .jpg, .jpeg">
       {{#input-submit}}submit image-submit{{/input-submit}}
     </div>
-    <button type="button" id="add-image-button" class="button add-image-button visuallyhidden">{{#t}}buttons.add-image{{/t}}</button>
+    <button type="button" id="add-image-button" class="button add-image-button visuallyhidden" tabindex="-1">{{#t}}buttons.add-image{{/t}}</button>
     <div class="link-margin">
       <p><a href="/check-your-report">{{#t}}pages.image.link{{/t}}</a></p>
     </div>

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -4,6 +4,12 @@ require('hof-theme-govuk');
 
 document.getElementById('add-image-button').classList.remove('visuallyhidden');
 
+document.getElementById('file-upload').tabIndex = -1;
+
+document.getElementById('image-submit').tabIndex = -1;
+
+document.getElementById('add-image-button').removeAttribute('tabindex');
+
 document.getElementById('add-image-button').addEventListener('click', function imgClick() {
   document.getElementById('file-upload').click();
 });

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "pre-commit": "^1.0.10",
     "sinon": "^4.1.2",
     "sinon-chai": "^2.14.0",
-    "so-acceptance": "^5.0.1"
+    "so-acceptance": "^5.1.0"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
* Some hidden elements should not have tab focus.  This is for screenreader and normal users.   It is confusing.
* There are different items hidden when JS is enabled and disabled.  This deals with both scenarios