### PR TITLE
Fix tab focus acceptance: use yield & assert

### DIFF
--- a/apps/rotm/acceptance/features/tab-focus.js
+++ b/apps/rotm/acceptance/features/tab-focus.js
@@ -1,10 +1,10 @@
 'use strict';
+const assert = require('assert');
 
 Feature('Accessibility Tab focus');
 
-Scenario('Given I am on image I can not tab into a hidden element', (
-  I
-) => {
+Scenario('Given I am on image I can not tab into a hidden element',
+  function *(I) {
   I.amOnPage('/');
   I.completeToStep('/image');
   // previously if you tabbed into the elements 6 times then the hidden element would get focused on
@@ -14,9 +14,6 @@ Scenario('Given I am on image I can not tab into a hidden element', (
   I.pressKey('Tab');
   I.pressKey('Tab');
   I.pressKey('Tab');
-  I.hasFocus('#file-upload')
-    .then((bool) => {
-      bool !== true;
-    }
-  );
+  const hiddenFocus = yield I.hasFocus('#file-upload');
+  assert.equal(false, hiddenFocus);
 });


### PR DESCRIPTION
- The test was not running properly
- The test was not following the best practices
- Use of yield with function * rather than as a promise
- Use of assert to fail the test if it does fail