### PR TITLE
[RTMD-181] - Move image alt content from /source

### DIFF
--- a/apps/rotm/translations/src/en/pages.json
+++ b/apps/rotm/translations/src/en/pages.json
@@ -1,10 +1,6 @@
 {
   "source": {
-    "header": "Where did you find the material?",
-    "intro": "A link or URL to the page is really helpful. If you don't have one, the name of the company or website is fine.",
-    "image": {
-      "alt": "You can find the link in the address bar above the page. It usually starts with www or http"
-    }
+    "header": "Where did you find the material?"
   },
   "more-info": {
     "header": "Can you tell us more about the material?",

--- a/apps/rotm/views/content/source.md
+++ b/apps/rotm/views/content/source.md
@@ -1,0 +1,3 @@
+A link or URL to the page is really helpful. If you don't have one, the name of the company or website is fine.
+
+You can find the link in the address bar above the page. It usually starts with www or http

--- a/apps/rotm/views/source.html
+++ b/apps/rotm/views/source.html
@@ -1,5 +1,6 @@
 {{<partials-page}}
   {{$page-content}}
+    {{#markdown}}source{{/markdown}}
     {{#fields}}
       {{#renderField}}{{/renderField}}
     {{/fields}}
@@ -8,7 +9,7 @@
   {{$sidebar}}
   <aside class="govuk-related-items">
     <h2>Where to find a link</h2>
-    <img src="{{assetPath}}/images/source-help.svg" alt="{{#t}}pages.source.image.alt{{/t}}" />
+    <img src="{{assetPath}}/images/source-help.svg" alt="" />
   </aside>
   {{/sidebar}}
 {{/partials-page}}


### PR DESCRIPTION
- Move the helpful content in the image alt text to the main body
- If it's useful then it should be for all users otherwise remove it
- It's not just for screenreader users