### PR TITLE
SD-107: field validators & their respective validation error messages 

### DIFF
--- a/apps/rotm/fields.js
+++ b/apps/rotm/fields.js
@@ -184,7 +184,7 @@ module.exports = {
     legend: {
       className: 'visuallyhidden'
     },
-    validate: 'required'
+    validate: ['required', 'notUrl']
   },
   'contact-details-method': {
     mixin: 'checkbox-group',
@@ -208,7 +208,7 @@ module.exports = {
       field: 'contact-details-method',
       value: 'email'
     },
-    validate: 'required'
+    validate: ['required', 'email']
   },
   'contact-phone': {
     disableRender: true,
@@ -216,6 +216,6 @@ module.exports = {
       field: 'contact-details-method',
       value: 'phone'
     },
-    validate: 'required'
+    validate: ['required', 'internationalPhoneNumber']
   }
 };

--- a/apps/rotm/translations/src/en/fields.json
+++ b/apps/rotm/translations/src/en/fields.json
@@ -122,7 +122,8 @@
     "label": "Telephone number",
     "hint": "For international numbers include the country code",
     "validation": {
-			"required": "Enter a phone number we can contact you on"
+			"required": "Enter a phone number we can contact you on",
+      "internationalPhoneNumber": "Enter a phone number we can contact you on"
 		}
   },
   "images": {

--- a/apps/rotm/translations/src/en/fields.json
+++ b/apps/rotm/translations/src/en/fields.json
@@ -93,7 +93,8 @@
   "contact-details-name": {
     "label": "Full name",
     "validation": {
-      "required": "Enter your full name"
+      "required": "Enter your full name",
+      "notUrl" : "Enter your full name"
     }
   },
   "contact-details-method": {


### PR DESCRIPTION
What?
An update that adds validators to 3 fields.

Why?
Users were able to submit urls through name field which could be identified as a phishing risk to HO employees.

Testing?
Tested locally, no issues.

Anything Else?
Locally I have a default.json file that lives in rotm/translations/en that responds positively only when edited with the validation error messages. Changing only the fields.json file with the validation error messages does not seem to output the respective validation error message and only outputs the generic 'There is a problem'.
