### PR TITLE
Upgraded hof-middlware to v2.2.4 to fix redirection to malicious site

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "hof-behaviour-emailer": "^2.2.1",
     "hof-behaviour-summary-page": "^3.1.0",
     "hof-build": "^2.0.0",
+    "hof-middleware": "^2.2.4",
     "hof-model": "^3.1.2",
     "hof-template-partials": "5.4.1",
     "hof-theme-govuk": "^5.2.4",


### PR DESCRIPTION
**What**
Upgraded hof-middlware to v2.2.4
**Why**
Applications using this library could be vulnerable to a redirection exploit where an attacker can use a Home Office page to redirect someone to their malicious site
**How**
In hof-middleware ensure URLs are relative paths – i.e. they start with a single / character. Absolute URLs starting with // will be rejected.
**Test**
Unit test and manual url test