### PR TITLE
Revert to new filevault image

### DIFF
--- a/kube/file-vault-deployment.yaml
+++ b/kube/file-vault-deployment.yaml
@@ -35,9 +35,7 @@ spec:
     spec:
       containers:
         - name: file-vault
-          # TEMP to maintain production integrity
-          image: quay.io/ukhomeofficedigital/file-vault:2936ce44e4ca1ad90b3b0526b9abf73c46000de2
-          # image: quay.io/ukhomeofficedigital/file-vault:bab000624c4323823cd4df723b44bc3bd29fec2c
+          image: quay.io/ukhomeofficedigital/file-vault:bab000624c4323823cd4df723b44bc3bd29fec2c
           imagePullPolicy: Always
           resources:
             limits:

--- a/kube/file-vault-ingress.yaml
+++ b/kube/file-vault-ingress.yaml
@@ -7,6 +7,9 @@ metadata:
   name: file-vault-ingress
   {{ end }}
 {{ file .INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
+    {{ if not (eq .KUBE_NAMESPACE .PROD_ENV) }}
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+    {{ end }}
 spec:
   tls:
   - hosts:

--- a/kube/ingress-external.yaml
+++ b/kube/ingress-external.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ .APP_NAME }}-external
   {{ end }}
 {{ file .INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
+    {{ if not (eq .KUBE_NAMESPACE .PROD_ENV) }}
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+    {{ end }}
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
Use latest filevault image that is tested and we know is working. Need to coordinate with caseworkers first before merging and deploying to ensure we don't unintentionally block access to them for previously submitted application images.