### PR TITLE
changed uat kube token as was set to old environment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -232,7 +232,7 @@ steps:
       KUBE_SERVER:
         from_secret: kube_server_dev
       KUBE_TOKEN:
-        from_secret: kube_token_dev
+        from_secret: kube_token_sas_dev
     commands:
       - bin/deploy.sh $${UAT_ENV}
     when:


### PR DESCRIPTION
**What?**
Changed the UAT environment kube token.

**Why?**
The wrong kube token was given to `deploy_to_uat` step.

**How?**
On ACP Hub, the rotm-uat has been created under a different service to what the previously used UAT environment, which means it would now use a different kube token.