### PR TITLE
host name changed

### DIFF
--- a/kube/app/ingress-external.yml
+++ b/kube/app/ingress-external.yml
@@ -15,7 +15,7 @@ spec:
         - {{ .DRONE_BUILD_NUMBER }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
         - {{ .APP_NAME }}-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-        - dev.notprod.{{ .APP_NAME }}.homeoffice.gov.uk
+        - rotm.uat.internal.sas-notprod.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
         - preprod.notprod.{{ .APP_NAME }}.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
@@ -30,7 +30,7 @@ spec:
     {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
     - host: {{ .APP_NAME }}-{{ .DRONE_SOURCE_BRANCH }}.{{ .BRANCH_ENV }}.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-    - host: dev.notprod.{{ .APP_NAME }}.homeoffice.gov.uk
+    - host: rotm.uat.internal.sas-notprod.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
     - host: preprod.notprod.{{ .APP_NAME }}.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}


### PR DESCRIPTION
**What?**
Changed the UAT hostname.

**Why?**
The hostname previously given is in a different format.

**How?**
When requesting rotm-uat namespace through acp, I asked for _rotm.uat.internal.sas-notprod.homeoffice.gov.uk_ as the domain name instead of _report-terrorist-material.uat.internal.sas-notprod.homeoffice.gov.uk_