### PR TITLE
ROTM-32-publish-cucumber-reports

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -48,6 +48,9 @@ sonar_scanner: &sonar_scanner
 acceptance_tests: &acceptance_tests
   pull: if-not-exists
   image: mcr.microsoft.com/playwright:v1.12.3-focal
+    environment:
+    CUCUMBER_PUBLISH_TOKEN:
+      from_secret: CUCUMBER_PUBLISH_TOKEN
 
 steps:
   - name: clone_repos

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,7 +48,7 @@ sonar_scanner: &sonar_scanner
 acceptance_tests: &acceptance_tests
   pull: if-not-exists
   image: mcr.microsoft.com/playwright:v1.12.3-focal
-    environment:
+  environment:
     CUCUMBER_PUBLISH_TOKEN:
       from_secret: CUCUMBER_PUBLISH_TOKEN
 


### PR DESCRIPTION
Enable CUCUMBER_PUBLISH_TOKEN to be consumed in drone.yml so that cucumber reports are published to the collection https://reports.cucumber.io/report-collections/1af00bc1-c58b-4b45-8fd8-ac69ff335d3c 

