### PR TITLE
ROTM-21: Replace email module with Gov Notify 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is built with [HOF](https://github.com/UKHomeOffice/hof) and uses [
 
 ## Getting started
 
-Get the project from Github
+Get the project from GitHub
 ```bash
 $ git clone git@github.com:UKHomeOffice/rotm.git && cd rotm
 ```

--- a/apps/rotm/behaviours/caseworker-email.js
+++ b/apps/rotm/behaviours/caseworker-email.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const Emailer = require('hof').components.emailer;
+const hof = require('hof');
+//const Emailer = hof.components.emailer;
+const Notify = hof.components.notify;
 const path = require('path');
 const moment = require('moment');
 const config = require('../../../config');
@@ -14,6 +16,7 @@ const logger = createLogger({
 
 const parse = (model, translate) => {
   const getLabel = key => translate(`email.caseworker.fields.${key}.label`);
+  const format = label => label.includes('?') ? label : label + ':';
   const fields = [
     'evidence-written',
     'contact-details-name',
@@ -43,15 +46,10 @@ const parse = (model, translate) => {
 };
 
 module.exports = settings => {
-  if (settings.transport !== 'stub' && !settings.from && !settings.replyTo) {
-    // eslint-disable-next-line no-console
-    console.warn('WARNING: Email `from` address must be provided. Falling back to stub email transport.');
-  }
-  return Emailer(Object.assign({}, settings, {
-    transport: settings.from ? settings.transport : 'stub',
+  return Notify(Object.assign({}, settings, {
     recipient: settings.caseworker,
     subject: (model, translate) => translate('email.caseworker.subject'),
     template: path.resolve(__dirname, '../emails/caseworker.html'),
     parse
-  }));
+  }))
 };

--- a/apps/rotm/behaviours/caseworker-email.js
+++ b/apps/rotm/behaviours/caseworker-email.js
@@ -32,17 +32,20 @@ const parse = (model, translate) => {
   });
 
   return {
-    urls: model.urls,
-    images: model.images,
-    table: [
-      { label: getLabel('uniqueId'), value: model.submissionID },
-      { label: getLabel('submitted'), value: submissionDateTime },
-      ...fields.map(f => ({
-        label: getLabel(f),
-        value: model[f]
-      }))
-    ]
-  };
+    data: {
+      title: "You have a new report of online terrorist material",
+      urls: model.urls,
+      images: model.images,
+      table: [
+        {label: getLabel('uniqueId'), value: model.submissionID},
+        {label: getLabel('submitted'), value: submissionDateTime},
+        ...fields.map(f => ({
+          label: getLabel(f),
+          value: model[f]
+        }))
+      ]
+    }
+  }
 };
 
 module.exports = settings => {

--- a/apps/rotm/behaviours/caseworker-email.js
+++ b/apps/rotm/behaviours/caseworker-email.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const hof = require('hof');
-//const Emailer = hof.components.emailer;
 const Notify = hof.components.notify;
 const path = require('path');
 const moment = require('moment');
@@ -16,7 +15,6 @@ const logger = createLogger({
 
 const parse = (model, translate) => {
   const getLabel = key => translate(`email.caseworker.fields.${key}.label`);
-  const format = label => label.includes('?') ? label : label + ':';
   const fields = [
     'evidence-written',
     'contact-details-name',
@@ -33,7 +31,7 @@ const parse = (model, translate) => {
 
   return {
     data: {
-      title: "You have a new report of online terrorist material",
+      title: 'You have a new report of online terrorist material',
       urls: model.urls,
       images: model.images,
       table: [
@@ -45,7 +43,7 @@ const parse = (model, translate) => {
         }))
       ]
     }
-  }
+  };
 };
 
 module.exports = settings => {
@@ -54,5 +52,5 @@ module.exports = settings => {
     subject: (model, translate) => translate('email.caseworker.subject'),
     template: path.resolve(__dirname, '../emails/caseworker.html'),
     parse
-  }))
+  }));
 };

--- a/apps/rotm/emails/caseworker.html
+++ b/apps/rotm/emails/caseworker.html
@@ -1,22 +1,22 @@
-<table width="100%" cellspacing="0" cellpadding="0" rules="none">
+{{#data}}
+  #{{title}}
   {{#table}}
-    {{#value}}
-    <tr>
-      <td width="40%" style="padding: 15px 0;border-bottom:1px solid #ccc;">{{label}}</td>
-      <td width="60%" style="padding: 15px 0;border-bottom:1px solid #ccc;">{{value}}</td>
-    </tr>
-    {{/value}}
+  {{#value}}
+    {{label}}: {{value}}
+  - - -
+  {{/value}}
   {{/table}}
-  {{#urls}}
-    <tr>
-      <td width="40%" style="padding: 15px 0;border-bottom:1px solid #ccc;">Link</td>
-      <td width="60%" style="padding: 15px 0;border-bottom:1px solid #ccc;">{{.}}</td>
-    </tr>
-  {{/urls}}
-  {{#images}}
-    <tr>
-      <td width="40%" style="padding: 15px 0;border-bottom:1px solid #ccc;">Image</td>
-      <td width="60%" style="padding: 15px 0;border-bottom:1px solid #ccc;"><a href="{{url}}">{{name}}</a></td>
-    </tr>
-  {{/images}}
-</table>
+<!--  {{#urls}}-->
+<!--    <tr>-->
+<!--      <td width="40%" style="padding: 15px 0;border-bottom:1px solid #ccc;">Link</td>-->
+<!--      <td width="60%" style="padding: 15px 0;border-bottom:1px solid #ccc;">{{.}}</td>-->
+<!--    </tr>-->
+<!--  {{/urls}}-->
+<!--  {{#images}}-->
+<!--    <tr>-->
+<!--      <td width="40%" style="padding: 15px 0;border-bottom:1px solid #ccc;">Image</td>-->
+<!--      <td width="60%" style="padding: 15px 0;border-bottom:1px solid #ccc;"><a href="{{url}}">{{name}}</a></td>-->
+<!--    </tr>-->
+<!--  {{/images}}-->
+{{/data}}
+

--- a/config.js
+++ b/config.js
@@ -31,7 +31,8 @@ module.exports = {
     region: process.env.EMAIL_REGION || '',
     caseworker: process.env.CASEWORKER_EMAIL ||  'sas-hof-test@digital.homeoffice.gov.uk',
     notifyApiKey: process.env.NOTIFY_KEY ,
-    notifyTemplate: process.env.NOTIFY_TEMPLATE || '5734dfd3-ea54-4b86-8914-0458d8895559'
+    notifyTemplate: process.env.NOTIFY_TEMPLATE || '5734dfd3-ea54-4b86-8914-0458d8895559',
+    applicant: 'email-text'
   },
   hosts: {
     acceptanceTests: process.env.ACCEPTANCE_HOST_NAME || `http://localhost:${process.env.PORT || 8080}`

--- a/config.js
+++ b/config.js
@@ -30,7 +30,7 @@ module.exports = {
     replyTo: process.env.REPLY_TO || '',
     region: process.env.EMAIL_REGION || '',
     caseworker: process.env.CASEWORKER_EMAIL ||  'sas-hof-test@digital.homeoffice.gov.uk',
-    notifyApiKey: process.env.NOTIFY_KEY ,
+    notifyApiKey: process.env.NOTIFY_KEY,
     notifyTemplate: process.env.NOTIFY_TEMPLATE || '5734dfd3-ea54-4b86-8914-0458d8895559',
     applicant: 'email-text'
   },

--- a/config.js
+++ b/config.js
@@ -29,20 +29,9 @@ module.exports = {
     from: process.env.FROM_ADDRESS || '',
     replyTo: process.env.REPLY_TO || '',
     region: process.env.EMAIL_REGION || '',
-    transport: process.env.EMAIL_TRANSPORT || 'smtp',
     caseworker: process.env.CASEWORKER_EMAIL ||  'sas-hof-test@digital.homeoffice.gov.uk',
-    transportOptions: {
-      accessKeyId: process.env.HOF_SES_USER || process.env.AWS_USER || '',
-      secretAccessKey: process.env.HOF_SES_PASSWORD || process.env.AWS_PASSWORD || '',
-      port: process.env.TRANSPORT_PORT || '587',
-      host: process.env.TRANSPORT_HOST || 'email-smtp.eu-west-1.amazonaws.com',
-      ignoreTLS: process.env.TRANSPORT_IGNORE_TLS || '',
-      secure: process.env.TRANSPORT_SECURE || false,
-      auth: {
-        user: process.env.HOF_SES_USER || process.env.AWS_USER,
-        pass: process.env.HOF_SES_PASSWORD || process.env.AWS_PASSWORD
-      }
-    }
+    notifyApiKey: process.env.NOTIFY_KEY ,
+    notifyTemplate: process.env.NOTIFY_TEMPLATE || '5734dfd3-ea54-4b86-8914-0458d8895559'
   },
   hosts: {
     acceptanceTests: process.env.ACCEPTANCE_HOST_NAME || `http://localhost:${process.env.PORT || 8080}`

--- a/config.js
+++ b/config.js
@@ -31,7 +31,7 @@ module.exports = {
     region: process.env.EMAIL_REGION || '',
     caseworker: process.env.CASEWORKER_EMAIL ||  'sas-hof-test@digital.homeoffice.gov.uk',
     notifyApiKey: process.env.NOTIFY_KEY,
-    notifyTemplate: process.env.NOTIFY_TEMPLATE || '5734dfd3-ea54-4b86-8914-0458d8895559',
+    notifyTemplate: process.env.NOTIFY_TEMPLATE || '8f707475-a51b-46ad-b2fb-0af67ae58524',
     applicant: 'email-text'
   },
   hosts: {

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -68,6 +68,11 @@ spec:
               {{ else }}
               value: redis
               {{ end }}
+            - name: NOTIFY_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hof-notify-key
+                  key: hof-notify-key
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/kube/create_secrets.sh
+++ b/kube/create_secrets.sh
@@ -1,2 +1,1 @@
 kubectl create secret generic redis --from-literal=session_secret=${SESSION_SECRET}
-kubectl create secret generic hof-notify-key --from-literal=hof-notify-key=${NOTIFY_KEY}

--- a/kube/create_secrets.sh
+++ b/kube/create_secrets.sh
@@ -1,1 +1,2 @@
 kubectl create secret generic redis --from-literal=session_secret=${SESSION_SECRET}
+kubectl create secret generic hof-notify-key --from-literal=hof-notify-key=${NOTIFY_KEY}


### PR DESCRIPTION
**What**
Replace the email module Nodemailer with Gov Notify 

**Why**
The hof-emailer package uses a module which contains a high vulnerability (nodemailer-smtp-transport https://www.npmjs.com/package/nodemailer-smtp-transport). This package hasn't been updated in five years so uses a vulnerable version of lodash. 

**How**
Updated the service code and config to use the hof notify component for sending caseworker and confirmation emails

**Test**
Manual testing in local, branch and UAT. Unit tests and automated tests 