### PR TITLE
WIP: ROTM-81 - Access uploaded files beyond standard time limit

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -93,6 +93,8 @@ spec:
                 secretKeyRef:
                   name: passwordhash
                   key: passwordhash
+            - name: ALLOW_GENERATE_LINK_ROUTE
+              value: "yes"
           securityContext:
             runAsNonRoot: true
 


### PR DESCRIPTION
## What?
set ALLOW_GENERATE_LINK_ROUTE to "yes" in file-vault

## Why?
Business requires access to uploaded files for atleast a month instead of the standard 7 days

## How?
ALLOW_GENERATE_LINK_ROUTE="yes" tells file-vault to regenerate signed urls whenever the url expires

## Testing?

TBD

## Screenshots (optional)

## Anything Else?
