### PR TITLE
HOFF-678: Add alt text to ROTM image upload

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,6 +2,14 @@
 version: v1.22.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+  SNYK-JS-ASYNC-7414156:
+    - '*':
+      reason: braces needs to be upgraded to the latest version
+      expires: '2025-02-09T00:00:00.000Z'
+  SNYK-JS-BRACES-6838727:
+    - '*':
+      reason: braces needs to be upgraded to the latest version
+      expires: '2024-09-28T00:00:00.000Z'
   SNYK-JS-EXPRESS-6474509:
     - '*':
         reason: express needs to be upgraded in HOF to lastest version
@@ -54,7 +62,7 @@ ignore:
   SNYK-JS-AXIOS-6032459:
     - '*':
         reason: Update notifications-node-client in HOF
-        expires: '2024-07-03T00:00:00.000Z'
+        expires: '2025-02-09T00:00:00.000Z'
         created: '2023-11-08T13:22:47.350Z'
   SNYK-JS-XML2JS-5414874:
     - '*':

--- a/apps/rotm/views/evidence-upload-confirm.html
+++ b/apps/rotm/views/evidence-upload-confirm.html
@@ -16,7 +16,7 @@
     {{#values.images}}
       <p>{{name}} - <a href="?delete={{id}}">Delete</a></p>
       <div class="image-wrapper">
-        <img src="{{thumbnail}}" width="300px">
+        <img src="{{thumbnail}}" width="300px" alt="">
       </div>
     {{/values.images}}
   {{/page-content}}


### PR DESCRIPTION
## What? 

Add alternative text to images that are uploaded on the ROTM form - [HOFF-678](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-678)

## Why? 

To resolve an accessibility issue identified from tests using the WAVE tool

## Screenshots (optional)

Before adding alternative text:
<img width="1314" alt="image" src="https://github.com/UKHomeOffice/rotm/assets/142597294/d6edc4db-857e-4ab8-8f9d-c7767df66bc5">

After adding alternative text:
<img width="1314" alt="image" src="https://github.com/UKHomeOffice/rotm/assets/142597294/eacaa4c5-d12a-499a-bce2-952ade08d89f">

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
