### PR TITLE
File-vault update with error handling for http response from clam av

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
         - name: file-vault
-          image: quay.io/ukhomeofficedigital/file-vault:bab000624c4323823cd4df723b44bc3bd29fec2c
+          image: quay.io/ukhomeofficedigital/file-vault:15acab8276f79fa899e09075264df453fa755214
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
**What**
Implement error handling for HTTP response codes in the 4xx and 5xx range returned from the ClamAV REST service.

**Why**
HTTP response codes in the 4xx and 5xx range from the ClamAV REST service are not checked, which poses a security risk, as files that have not been properly scanned due to misconfiguration or downtime of the ClamAV service could be falsely marked as safe and uploaded to the storage, potentially allowing malicious files to bypass our security measures.

**How**
Check for http response status codes that are greater than or equal to 400 and raise an error.

**Test**
Testing in branch and UAT