### PR TITLE
HOFF-814 - Capture and add user's ip address to the email to caseworker

### DIFF
--- a/apps/rotm/behaviours/caseworker-email.js
+++ b/apps/rotm/behaviours/caseworker-email.js
@@ -7,6 +7,14 @@ const moment = require('moment');
 const config = require('../../../config');
 const { createLogger, format, transports } = require('winston');
 const { combine, timestamp, json } = format;
+const http = require('http');
+
+let ipAddress = "";
+http.get({'host': 'api.ipify.org', 'port': 80, 'path': '/'}, function(resp) {
+  resp.on('data', function(ip) {
+    ipAddress = String.fromCharCode(...ip);
+  });
+});
 
 const logger = createLogger({
   format: combine(timestamp(), json()),
@@ -26,7 +34,7 @@ const parse = (model, translate) => {
 
   logger.log({
     level: 'info',
-    message: `Submission ID: ${model.submissionID}, Email Submitted: ${submissionDateTime}`
+    message: `Submission ID: ${model.submissionID}, Email Submitted: ${submissionDateTime}, IP Address:  ${ipAddress}`
   });
 
   return {
@@ -37,6 +45,7 @@ const parse = (model, translate) => {
       table: [
         {label: getLabel('uniqueId'), value: model.submissionID},
         {label: getLabel('submitted'), value: submissionDateTime},
+        {label: getLabel('ipaddress'), value: ipAddress},
         ...fields.map(f => ({
           label: getLabel(f),
           value: model[f]
@@ -47,7 +56,7 @@ const parse = (model, translate) => {
 };
 
 module.exports = settings => {
-  return Notify(Object.assign({}, settings, {
+return Notify(Object.assign({}, settings, {
     recipient: settings.caseworker,
     subject: (model, translate) => translate('email.caseworker.subject'),
     template: path.resolve(__dirname, '../emails/caseworker.html'),

--- a/apps/rotm/translations/src/en/email.json
+++ b/apps/rotm/translations/src/en/email.json
@@ -8,14 +8,14 @@
       "submitted": {
         "label": "Date and time of submission"
       },
+      "ipaddress": {
+        "label": "User ip address"
+      },
       "url": {
         "label": "Link"
       },
       "evidence-written": {
         "label": "Additional details"
-      },
-      "url": {
-        "label": "Link"
       },
       "contact-details-name": {
         "label": "Full name"

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   "bugs": "https://github.com/UKHomeOffice/rotm/issues",
   "scripts": {
     "start": "node server.js",
-    "start:dev": "hof-build watch",
-    "dev": "hof-build watch --env",
+    "start:dev": "hof-build watch --env",
     "test": "yarn run test:lint",
     "test:lint": "eslint . --config ./node_modules/eslint-config-hof/default.js",
     "test:unit": "mocha \"test/test.setup.js\" \"test/_unit/**/*.spec.js\"",


### PR DESCRIPTION
**What**
Capture the IP address of the user when they submit the form and add it to email sent to the caseworker
[HOFF-814](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-814)

**Why**
Requested by the police to enable them to trace the user in an emergency. 

**How**
Use the ipify public API to retrieve the IP address and add it is another field to the email

**Test**
Testing in branch and UAT

**Other**
This change is critical due to the urgency and importance of the information for police investigations.


