### PR TITLE
ROTM-128 adding ext ingress to service so it can read the white list

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -30,12 +30,12 @@ if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
-  $kd -f kube/app/ingress-internal.yml -f kube/app/networkpolicy-internal.yml
+  $kd -f kube/app/ingress-internal.yml -f kube/app/ingress-external.yml -f kube/app/networkpolicy-internal.yml -f kube/app/networkpolicy-external.yml
   $kd -f kube/redis -f kube/file-vault -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
-  $kd -f kube/app/ingress-internal.yml -f kube/app/networkpolicy-internal.yml
+  $kd -f kube/app/ingress-internal.yml -f kube/app/ingress-external.yml -f kube/app/networkpolicy-internal.yml -f kube/app/networkpolicy-external.yml
   $kd -f kube/redis -f kube/file-vault -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml


### PR DESCRIPTION
## What? 
we need to lock down the external UAT to home office network/POISE only - it should not be available to the public

## Why?
[https://uat.notprod.report-terrorist-material.homeoffice.gov.uk/] is accessible to public

## How? 
Change deploy.sh scripts to allow the deployment to have an external ingress (https://github.com/UKHomeOffice/rotm/commit/0e904f8648b349611e433c5a413754f640fe7d34)

## Anything Else? (optional)
Will check manually after redeployment
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] I will squash the commits before merging
