### PR TITLE
ROTM-174 Update to URLs

### DIFF
--- a/apps/rotm/fields/index.js
+++ b/apps/rotm/fields/index.js
@@ -2,11 +2,12 @@
 
 const path = require('path');
 // First pattern of regex allows for URLs using "www" or "http://" or "https://" as a prefix
-const http = '(https:\\/\\/)?(www\\.[a-zA-Z0-9-]{1,63}\\.[a-z]{2,6}([-a-zA-Z0-9@:%_\\+.~#?&//=]*)\\b(?!(\\w|\\d))';
+// eslint-disable-next-line max-len
+const http = '(?:https?:\\/\\/(?!\\/\\/)(?:www\\.)?[a-zA-Z0-9-]{1,63}(?:\\.[a-zA-Z0-9-]{1,63})*\\.[a-z]{2,6}(?:[\\/?#][^\\s]*)?\\/?)';
 // Second pattern of regex allows for URLs with no prefix e.g. example.com
-const URL = '[a-zA-Z0-9-]{1,63}\\.[a-z]{2,6}([-a-zA-Z0-9@:%_\\+.~#?&//=]*)\\b(?!(\\w|\\d)))';
+const URL = '(?:[a-zA-Z0-9-]{1,63}(?:\\.[a-zA-Z0-9-]{1,63})*\\.[a-z]{2,6}(?:[\\/?#][^\\s]*)?\\/?)';
 // Combines the above two URL patterns and also allows for empty values
-const URLRegex = new RegExp(`^$|^${http}|${URL}$`);
+const URLRegex = new RegExp(`^(?:$|${http}|${URL})$`);
 
 function extname(value) {
   return value && [


### PR DESCRIPTION
## What? 
[ROTM-174](https://collaboration.homeoffice.gov.uk/jira/browse/ROTM-174)

Updated the URL validation regex to make it more flexible. The new pattern now:

- Accepts both http:// and https:// URLs.

- Allows an optional trailing /.

- Prevents invalid protocols such as triple slashes (http:///).

- Supports domains with multiple subdomains (e.g., google.co.uk).

- Continues to accept URLs without a protocol (e.g., example.com).

- Maintains protection against invalid TLDs (letters only, 2–6 characters).

## Why? 
Users have complained that they are not able to submit particular common websites with certain URLs patterns.

## How? 
- Changed Regex

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
