### PR TITLE
adding the correct admin-ui address and removing wildcard

### DIFF
--- a/kube/app/ingress-external.yml
+++ b/kube/app/ingress-external.yml
@@ -19,7 +19,7 @@ spec:
         - stg.prod.{{ .APP_NAME }}.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
         - {{ .PRODUCTION_URL }}
-        - "*.prod.report-terrorist-material.homeoffice.gov.uk"
+        - "admin-ui.prod.report-terrorist-material.homeoffice.gov.uk"
       {{ end }}
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
       secretName: branch-tls-external


### PR DESCRIPTION
## What?
This pull request makes a minor adjustment to the ingress configuration for the production environment. The change restricts the allowed host to a specific subdomain rather than a wildcard domain, improving security and specificity.

- Ingress host configuration: Updated the production ingress rule in `kube/app/ingress-external.yml` to allow only `admin-ui.prod.report-terrorist-material.homeoffice.gov.uk` instead of the wildcard `*.prod.report-terrorist-material.homeoffice.gov.uk`.

## Why?
To fix prod issues

## How?
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
