### PR TITLE
scaling back down resources are adding HAproxy

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -51,7 +51,7 @@ unit_tests: &unit_tests
 
 sonar_scanner: &sonar_scanner
   pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/sonar-scanner-nodejs:v0.0.1
+  image: quay.io/ukhomeofficedigital/sonar-scanner:latest
   commands:
     - sonar-scanner -Dproject.settings=./sonar-project.properties
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -51,7 +51,7 @@ unit_tests: &unit_tests
 
 sonar_scanner: &sonar_scanner
   pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/sonar-scanner-nodejs:latest
+  image: quay.io/ukhomeofficedigital/sonar-scanner-nodejs:v0.0.1
   commands:
     - sonar-scanner -Dproject.settings=./sonar-project.properties
 

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -15,7 +15,7 @@ metadata:
   {{ end }}
 spec:
   {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-  replicas: 15
+  replicas: 3
   {{ else }}
   replicas: 1
   {{ end }}


### PR DESCRIPTION
## What?
This pull request makes a small change to the deployment configuration. It reduces the number of replicas for the production environment from 15 to 3 in the `kube/app/deployment.yml` file.

## Why?
To scale down the resources now that the HA Proxy is in place

## How?
Setting the replicas

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
