### PR TITLE
ROTM-112-PVC to stg and prod only

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -204,9 +204,6 @@ steps:
         from_secret: kube_server_dev
       KUBE_TOKEN:
         from_secret: kube_token_sas_dev
-      REDIS_PERSISTENCE_ENABLED: "true"
-      REDIS_PERSISTENCE_SIZE: "1Gi"
-      REDIS_PERSISTENCE_STORAGE_CLASS: ""
     commands:
       - bin/deploy.sh $${BRANCH_ENV}
     when:
@@ -336,7 +333,7 @@ steps:
       KUBE_TOKEN:
         from_secret: kube_token_prod
       REDIS_PERSISTENCE_ENABLED: "true"
-      REDIS_PERSISTENCE_SIZE: "5Gi"
+      REDIS_PERSISTENCE_SIZE: "10Gi"
     commands:
       - bin/deploy.sh $${PROD_ENV}
     when:

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -15,15 +15,45 @@ export OPENRESTY_SETTINGS=$HOF_CONFIG/openresty-settings.yaml
 
 kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 
-redis_storage_files='kube/redis/redis-persistent-volume-claim.yml'
-redis_runtime_files='kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml'
+deploy_redis() {
+  # Only STG/PROD create a PVC; other envs stay non-persistent.
+
+  if [[ "${REDIS_PERSISTENCE_ENABLED}" == "true" && -z "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+    $kd -f kube/redis/redis-persistent-volume-claim.yml
+  fi
+
+  $kd -f kube/redis/redis-service.yml \
+    -f kube/redis/redis-network-policy.yml \
+    -f kube/redis/redis-deployment.yml
+}
+
+delete_redis() {
+  if [[ "${REDIS_PERSISTENCE_ENABLED}" == "true" && -z "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+    $kd --delete -f kube/redis/redis-persistent-volume-claim.yml
+  fi
+
+  $kd --delete -f kube/redis/redis-service.yml \
+    -f kube/redis/redis-network-policy.yml \
+    -f kube/redis/redis-deployment.yml
+}
 
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
   export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
 
+  export REDIS_PERSISTENCE_ENABLED=$(echo "${REDIS_PERSISTENCE_ENABLED:-true}" | tr '[:upper:]' '[:lower:]')
+  export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
+  export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-gp2-encrypted-eu-west-2b}
+  export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
+  export REDIS_PERSISTENCE_ANNOTATIONS_FILE=${REDIS_PERSISTENCE_ANNOTATIONS_FILE:-}
+
+  if [[ -z "${REDIS_PERSISTENCE_SIZE}" ]]; then
+    export REDIS_PERSISTENCE_SIZE=1Gi
+  fi
+
   $kd --delete -f kube/configmaps/configmap.yml
-  $kd --delete -f kube/redis -f kube/file-vault -f kube/app -f kube/ui-redis/ui-redis-statefulset.yml -f kube/ui-redis/ui-redis-service.yml -f kube/ui-redis/ui-redis-pvc.yml -f kube/ui-redis/ui-redis-network-policy.yml -f kube/ui-redis/ui-redis-configmap.yml -f kube/openresty
+  delete_redis
+  $kd --delete -f kube/file-vault -f kube/app -f kube/ui-redis/ui-redis-statefulset.yml -f kube/ui-redis/ui-redis-service.yml -f kube/ui-redis/ui-redis-pvc.yml -f kube/ui-redis/ui-redis-network-policy.yml -f kube/ui-redis/ui-redis-configmap.yml -f kube/openresty
   $kd --delete -f kube/ha-proxy/ha-proxy-statefulset.yml -f kube/ha-proxy/ha-proxy-public-service.yml -f kube/ha-proxy/ha-proxy-peer-service.yml -f kube/ha-proxy/ha-proxy-network-policy.yml -f kube/ha-proxy/ha-proxy-configmap.yml
   echo "Torn Down Branch - $APP_NAME-$DRONE_SOURCE_BRANCH.internal.$BRANCH_ENV.homeoffice.gov.uk"
   exit 0
@@ -31,18 +61,21 @@ fi
 
 export KUBE_NAMESPACE=$1
 export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
-export REDIS_PERSISTENCE_ENABLED=${REDIS_PERSISTENCE_ENABLED:-true}
+export REDIS_PERSISTENCE_ENABLED=$(echo "${REDIS_PERSISTENCE_ENABLED:-true}" | tr '[:upper:]' '[:lower:]')
 export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
 export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-gp2-encrypted-eu-west-2b}
 export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
 export REDIS_PERSISTENCE_ANNOTATIONS_FILE=${REDIS_PERSISTENCE_ANNOTATIONS_FILE:-}
 
-if [[ -z "${REDIS_PERSISTENCE_SIZE}" ]]; then
-  if [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
-    export REDIS_PERSISTENCE_SIZE=10Gi
-  else
-    export REDIS_PERSISTENCE_SIZE=1Gi
-  fi
+# Redis PVC is STG/PROD only, with fixed sizes.
+if [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
+  export REDIS_PERSISTENCE_ENABLED=true
+  export REDIS_PERSISTENCE_SIZE=10Gi
+elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
+  export REDIS_PERSISTENCE_ENABLED=true
+  export REDIS_PERSISTENCE_SIZE=1Gi
+else
+  export REDIS_PERSISTENCE_ENABLED=false
 fi
 
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
@@ -50,7 +83,8 @@ if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
 
   $kd -f kube/file-vault/file-vault-ingress.yml # deploy ingress first so file-vault can use its tls-secret in its keycloak certs
   $kd -f kube/configmaps -f kube/certs
-  $kd -f kube/redis -f kube/file-vault -f kube/app
+  deploy_redis
+  $kd -f kube/file-vault -f kube/app
   $kd -f kube/ui-redis
   $kd -f kube/openresty/admin-ui-deployment.yml -f kube/openresty/admin-ui-ingress-internal.yml -f kube/openresty/admin-ui-network-policy.yml -f kube/openresty/admin-ui-service.yml -f kube/openresty/openresty-configmap.yml -f kube/openresty/openresty-deployment.yml -f kube/openresty/openresty-network-policy.yml -f kube/openresty/openresty-service.yml
   $kd -f kube/ha-proxy
@@ -58,7 +92,8 @@ elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/app/ingress-internal.yml -f kube/app/ingress-external.yml -f kube/app/networkpolicy-internal.yml -f kube/app/networkpolicy-external.yml
-  $kd -f kube/redis -f kube/file-vault -f kube/app/deployment.yml
+  deploy_redis
+  $kd -f kube/file-vault -f kube/app/deployment.yml
   $kd -f kube/ui-redis
   $kd -f kube/openresty/admin-ui-deployment.yml -f kube/openresty/admin-ui-ingress-internal.yml -f kube/openresty/admin-ui-network-policy.yml -f kube/openresty/admin-ui-service.yml -f kube/openresty/openresty-configmap.yml -f kube/openresty/openresty-deployment.yml -f kube/openresty/openresty-network-policy.yml -f kube/openresty/openresty-service.yml
   $kd -f kube/ha-proxy
@@ -66,8 +101,8 @@ elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/app/ingress-internal.yml -f kube/app/ingress-external.yml -f kube/app/networkpolicy-internal.yml -f kube/app/networkpolicy-external.yml
-  $kd -f $redis_storage_files
-  $kd -f $redis_runtime_files -f kube/hof-rds-api -f kube/html-pdf -f kube/file-vault
+  deploy_redis
+  $kd -f kube/hof-rds-api -f kube/html-pdf -f kube/file-vault
   $kd -f kube/ui-redis
   $kd -f kube/openresty/admin-ui-deployment.yml -f kube/openresty/admin-ui-ingress-internal.yml -f kube/openresty/admin-ui-network-policy.yml -f kube/openresty/admin-ui-service.yml -f kube/openresty/openresty-configmap.yml -f kube/openresty/openresty-deployment.yml -f kube/openresty/openresty-network-policy.yml -f kube/openresty/openresty-service.yml
   $kd -f kube/ha-proxy
@@ -75,8 +110,8 @@ elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/app/ingress-external.yml -f kube/app/networkpolicy-external.yml
-  $kd -f $redis_storage_files
-  $kd -f $redis_runtime_files -f kube/hof-rds-api -f kube/html-pdf -f kube/file-vault
+  deploy_redis
+  $kd -f kube/hof-rds-api -f kube/html-pdf -f kube/file-vault
   $kd -f kube/ui-redis
   $kd -f kube/openresty/admin-ui-deployment.yml -f kube/openresty/admin-ui-ingress-external.yml -f kube/openresty/admin-ui-network-policy.yml -f kube/openresty/admin-ui-service.yml -f kube/openresty/openresty-configmap.yml -f kube/openresty/openresty-deployment.yml -f kube/openresty/openresty-network-policy.yml -f kube/openresty/openresty-service.yml
   $kd -f kube/ha-proxy


### PR DESCRIPTION
## What?
This pull request makes adjustments to the Redis persistence configuration in the `.drone.yml` deployment pipeline. The main focus is on updating or removing Redis persistence settings for different environments.

**Redis persistence configuration changes:**

* Removed `REDIS_PERSISTENCE_ENABLED`, `REDIS_PERSISTENCE_SIZE`, and `REDIS_PERSISTENCE_STORAGE_CLASS` environment variables from the development deployment step, indicating that Redis persistence is no longer configured for the dev environment.
* Increased `REDIS_PERSISTENCE_SIZE` from `5Gi` to `10Gi` for the production deployment step, providing more storage for Redis persistence in production.

## Why?
No need for the PVC in the dev space

## How?
Code refactor

## Testing?

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
