### PR TITLE
feat: adding custom dependabot configuration to update package.json and lock file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: "/"
+    versioning-strategy: increase
     schedule:
       interval: daily
       time: "06:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "06:00"
+      timezone: "Europe/London"
+    target-branch: "master"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    commit-message:
+      prefix: deps
+    pull-request-branch-name:
+      separator: "-"
+    rebase-strategy: auto
+    groups:
+      hof-dependency:
+        applies-to: version-updates
+        patterns:
+          - "hof"
+      patch-and-minor:
+        update-types:
+          - patch
+          - minor
+        exclude-patterns:
+          - "hof"


### PR DESCRIPTION
## What?

This PR introduces a custom dependabot configuration file to enable automatic package management (including HOF).

## Why?

Currently dependabot only updates the `yarn.lock` and doesn't automatically manage HOF versions. This is an issue because we need both the package.json and yarn.lock files updating to ensure consistency of automatic dependency management. We also want a way to automatically raise PR's when a HOF version change is detected.

## How?

Added a custom dependabot configuration file to manage all packages and update both yarn.lock and package.json.

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
