### PR TITLE
build: sanitising branch name to remove underscores and shorted dependabot naming

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -17,7 +17,41 @@ kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 
 sanitize_branch_name() {
   local raw_branch="$1"
+  local dependabot_payload
+  local dependabot_package
+  local dependabot_version
   local sanitized_branch
+
+  # Rewrite Dependabot npm/yarn master update branches to a shorter, meaningful slug.
+  # Example: dependabot-npm_and_yarn-master-eslint-10.4.1 -> dependabot-eslint-10.4.1
+  if [[ "$raw_branch" =~ ^dependabot[-/]npm_and_yarn[-/](master|main)[-/](.+)$ ]]; then
+    dependabot_payload="${BASH_REMATCH[2]}"
+    dependabot_payload=$(echo "$dependabot_payload" | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+
+    if [[ "$dependabot_payload" =~ ^(.+)-([0-9][0-9a-zA-Z.+-]*)$ ]]; then
+      dependabot_package="${BASH_REMATCH[1]}"
+      dependabot_version="${BASH_REMATCH[2]}"
+
+      dependabot_package=$(echo "$dependabot_package" | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')
+      dependabot_version=$(echo "$dependabot_version" | sed -E 's/[^0-9a-z.-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')
+
+      if [[ -n "$dependabot_package" && -n "$dependabot_version" ]]; then
+        sanitized_branch="dependabot-${dependabot_package}-${dependabot_version}"
+      fi
+    fi
+  fi
+
+  if [[ -n "$sanitized_branch" ]]; then
+    sanitized_branch="${sanitized_branch:0:60}"
+    sanitized_branch=$(echo "$sanitized_branch" | sed -E 's/-+$//')
+
+    if [[ -z "$sanitized_branch" ]]; then
+      sanitized_branch='branch'
+    fi
+
+    echo "$sanitized_branch"
+    return
+  fi
 
   sanitized_branch=$(echo "$raw_branch" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -15,6 +15,27 @@ export OPENRESTY_SETTINGS=$HOF_CONFIG/openresty-settings.yaml
 
 kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 
+sanitize_branch_name() {
+  local raw_branch="$1"
+  local sanitized_branch
+
+  sanitized_branch=$(echo "$raw_branch" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')
+
+  if [[ -z "$sanitized_branch" ]]; then
+    sanitized_branch='branch'
+  fi
+
+  # Keep branch slug short so generated Kubernetes resource names remain within DNS label limits.
+  sanitized_branch="${sanitized_branch:0:40}"
+  sanitized_branch=$(echo "$sanitized_branch" | sed -E 's/-+$//')
+
+  if [[ -z "$sanitized_branch" ]]; then
+    sanitized_branch='branch'
+  fi
+
+  echo "$sanitized_branch"
+}
+
 deploy_redis() {
   # Only STG/PROD create a PVC; other envs stay non-persistent.
 
@@ -39,7 +60,7 @@ delete_redis() {
 
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
-  export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
+  export DRONE_SOURCE_BRANCH=$(sanitize_branch_name "$(cat /root/.dockersock/branch_name.txt)")
 
   export REDIS_PERSISTENCE_ENABLED=$(echo "${REDIS_PERSISTENCE_ENABLED:-true}" | tr '[:upper:]' '[:lower:]')
   export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
@@ -60,7 +81,7 @@ if [[ $1 == 'tear_down' ]]; then
 fi
 
 export KUBE_NAMESPACE=$1
-export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+export DRONE_SOURCE_BRANCH=$(sanitize_branch_name "${DRONE_SOURCE_BRANCH}")
 export REDIS_PERSISTENCE_ENABLED=$(echo "${REDIS_PERSISTENCE_ENABLED:-true}" | tr '[:upper:]' '[:lower:]')
 export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
 export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-gp2-encrypted-eu-west-2b}


### PR DESCRIPTION
## What?

Introduce a branch name sanitisation function to replace underscores with hyphens and shorten to 40 characters to avoid DNS issues with the 63 char limit.

## Why?

Dependabot PR's follow a specific structure which mostly can't be changed. So for example the following dependabot PR branch name: `fv-dependabot-npm_and_yarn-master-hof-dependency-b4f7b4df17.rotm-branch.homeoffice.gov.uk` 

This part: `dependabot-npm_and_yarn-master-hof-dependency-b4f7b4df17` is standard and can't be changed. This is an issue because ACP Kubernetes policy doesn't allow for DNS names containing underscores or > 63 chars.

## How?

Added a simple sanitisation function that fixes the above issue. 

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
